### PR TITLE
Performance Improvement and IE7 Bug Fix

### DIFF
--- a/respond.src.js
+++ b/respond.src.js
@@ -223,8 +223,8 @@
 		xmlHttp = (function() {
 			var xmlhttpmethod = false,
 				attempts = [
-					function(){ return new ActiveXObject("Microsoft.XMLHTTP") },
-					function(){ return new XMLHttpRequest() }		
+					function(){ return new XMLHttpRequest() },
+					function(){ return new ActiveXObject("Microsoft.XMLHTTP") }
 				],
 				al = attempts.length;
 		


### PR DESCRIPTION
This patch fixes the IE7 child selector bug (https://github.com/scottjehl/Respond/issues/21) by appending `style` elements directly to `head` before setting their `cssText` rather than adding them to a `documentFragment` and appending that to `head`.

I didn't change the `insertBefore lastLink.nextSibling` line otherwise, so that will need to be changed if the order of the elements in the DOM is important.

I've also modified `applyMedia` to bail if no styles change on resize. Resizing seems much smoother now.
