### PR TITLE
Selectivizr compatibility

### DIFF
--- a/respond.src.js
+++ b/respond.src.js
@@ -40,16 +40,22 @@
 
 				//only links plz and prevent re-parsing
 				if( !!href && isCSS && !parsedSheets[ href ] ){
-					if( !/^([a-zA-Z]+?:(\/\/)?)/.test( href ) 
-						|| href.replace( RegExp.$1, "" ).split( "/" )[0] === win.location.host ){
-						requestQueue.push( {
-							href: href,
-							media: media
-						} );
-					}
-					else{
+					// selectivizr exposes css through the rawCssText expando
+					if (sheet.styleSheet.rawCssText) {
+						translate( sheet.styleSheet.rawCssText, href, media );
 						parsedSheets[ href ] = true;
-					}	
+					} else {
+						if( !/^([a-zA-Z]+?:(\/\/)?)/.test( href )
+							|| href.replace( RegExp.$1, "" ).split( "/" )[0] === win.location.host ){
+							requestQueue.push( {
+								href: href,
+								media: media
+							} );
+						}
+						else{
+							parsedSheets[ href ] = true;
+						}
+					}
 				}
 			}
 			makeRequests();


### PR DESCRIPTION
Added selectivizr compatibility by testing for the <code>styleSheet.rawCssText</code> expando property set by selectivizr and using it's content if it exists.

Selectivizr must be run first.
