### PR TITLE
This adds support for a cross-domain request to fetch the CSS files

### DIFF
--- a/respond.src.js
+++ b/respond.src.js
@@ -23,7 +23,7 @@
 		head 			= doc.getElementsByTagName( "head" )[0] || docElem,
 		links			= head.getElementsByTagName( "link" ),
 		requestQueue	= [],
-		isXDomainRequest = window.XDomainRequest,
+		isXDomainRequest = win.XDomainRequest,
 		
 		//loop stylesheets, send text content to translate
 		ripCSS			= function(){


### PR DESCRIPTION
This allows for a CDN hosted CSS file on a separate domain to work with respond.js for browsers that support it (e.g. IE8).  It naturally falls back to an HXR onerror.

Effectively, this adds support for CDNs in IE8, without having to use an iframe.
