### PR TITLE
Fix for Firefox 3 error: "TypeError: sheet.styleSheet is undefined"

### DIFF
--- a/respond.src.js
+++ b/respond.src.js
@@ -41,7 +41,7 @@
 				//only links plz and prevent re-parsing
 				if( !!href && isCSS && !parsedSheets[ href ] ){
 					// selectivizr exposes css through the rawCssText expando
-					if (sheet.styleSheet.rawCssText) {
+					if (sheet.styleSheet && sheet.styleSheet.rawCssText) {
 						translate( sheet.styleSheet.rawCssText, href, media );
 						parsedSheets[ href ] = true;
 					} else {


### PR DESCRIPTION
Fix for Firefox 3 error: "TypeError: sheet.styleSheet is undefined"

Extra object detection to prevent error in an if-statement:

OLD
if (sheet.styleSheet.rawCssText)

NEW
if (sheet.styleSheet && sheet.styleSheet.rawCssText)
