### PR TITLE
Fixing the NOT ENOUGH PARAMETERS exception thrown by Firefox 3.0.x (Simil

### DIFF
--- a/cross-domain/respond-proxy.html
+++ b/cross-domain/respond-proxy.html
@@ -25,7 +25,7 @@
 				if ( req.readyState == 4 ){
 					return;
 				}
-				req.send();
+				req.send( null );
 			};
 			
 			//define ajax obj 


### PR DESCRIPTION
Fixing the NOT ENOUGH PARAMETERS exception thrown by Firefox 3.0.x (Similar issue as #33)
