### PR TITLE
Ran into another Firefox 3.0 bug with the cross-domain proxy.

### DIFF
--- a/cross-domain/respond.proxy.js
+++ b/cross-domain/respond.proxy.js
@@ -95,6 +95,9 @@
 			if( thislink.rel.indexOf( "stylesheet" ) >= 0 && ext.test( href ) ){
 				(function( link ){			
 					fakejax( href, function( css ){
+						if (typeof(link.styleSheet) == 'undefined') {
+							link.styleSheet = {};
+						}
 						link.styleSheet.rawCssText = css;
 						respond.update();
 					} );


### PR DESCRIPTION
FX 3.0 spits out an error if link.styleSheet is undefined.  Checking if undefined and then setting to empty object before rawCssText gets set.
