### PR TITLE
IE7 Access is Denied error with network-path references ("//example.com/example.css")

### DIFF
--- a/respond.src.js
+++ b/respond.src.js
@@ -45,7 +45,7 @@
 						translate( sheet.styleSheet.rawCssText, href, media );
 						parsedSheets[ href ] = true;
 					} else {
-						if( !/^([a-zA-Z]+?:(\/\/)?)/.test( href )
+						if( !/^(([a-zA-Z]+:)?(\/\/))/.test( href )
 							|| href.replace( RegExp.$1, "" ).split( "/" )[0] === win.location.host ){
 							requestQueue.push( {
 								href: href,


### PR DESCRIPTION
It seems to me like the regular expression on line 48 that's checking to see whether a stylesheet's href is external or not doesn't correctly identify "protocol-less" network-path references as being external. For instance, suppose I'm including some YUI CSS file from Google's CDN (and I want to fetch it using whatever protocol the page was delivered in), in my link tag, I would set the href to this: "//ajax.googleapis.com/ajax/libs/yui/2.9.0/build/base/base-min.css"

Respond.js erroneously thinks this is a local file and adds it to the requestQueue, and in IE7, I see an "Access is denied" error on the page.

I believe my updated regular expression correctly treats network-path references as external while still treating everything else the same (though I would love to have other people take a look at it and make sure).
