### PR TITLE
Fixing media query regular expression.

### DIFF
--- a/respond.src.js
+++ b/respond.src.js
@@ -108,7 +108,7 @@
 				}
 				//parse for styles
 				else{
-					fullq	= qs[ i ].match( /@media ([^\{]+)\{([\S\s]+?)$/ ) && RegExp.$1;
+					fullq	= qs[ i ].match( /@media\s*([^\{]+)\{([\S\s]+?)$/ ) && RegExp.$1;
 					rules.push( RegExp.$2 && repUrls( RegExp.$2 ) );
 				}
 				


### PR DESCRIPTION
One small change to the regular expression that parses media queries to avoid the need of a space between the @media keyword and the first parenthesis.
