### PR TITLE
Resolves issue #100: CDN/x-domain setup fails in IE7 and IE6 when <base>...

### DIFF
--- a/cross-domain/respond.proxy.js
+++ b/cross-domain/respond.proxy.js
@@ -3,6 +3,7 @@
 	var docElem			= doc.documentElement,
 		proxyURL		= doc.getElementById("respond-proxy").href,
 		redirectURL		= (doc.getElementById("respond-redirect") || location).href,
+		baseElem		= doc.getElementsByTagName("base")[0],
 		urls			= [],
 		refNode;
 
@@ -25,7 +26,7 @@
 			docElem.insertBefore(iframe, docElem.firstElementChild || docElem.firstChild );
 		}
 
-		iframe.src = proxyURL + "?url=" + redirectURL + "&css=" + url;
+		iframe.src = checkBaseURL(proxyURL) + "?url=" + redirectURL + "&css=" + checkBaseURL(url);
 		
 		function checkFrameName() {
 			var cssText;
@@ -60,6 +61,15 @@
 		
 		win.setTimeout(checkFrameName, 500);
 	}
+
+	function checkBaseURL(href) {
+		if (baseElem && href.indexOf(baseElem.href) === -1) {
+			bref = (/\/$/).test(baseElem.href) ? baseElem.href : (baseElem.href + "/");
+			href = bref + href;
+		}
+
+		return href;
+	}
 	
 	function checkRedirectURL() {
 		// IE6 & IE7 don't build out absolute urls in <link /> attributes.
@@ -67,7 +77,6 @@
 		// This trickery resolves that issue.
 		if (~ !redirectURL.indexOf(location.host)) {
 
-			// Inject an <a> attribute, with the redirectURL
 			var fakeLink = doc.createElement("div");
 
 			fakeLink.innerHTML = '<a href="' + redirectURL + '"></a>';
@@ -89,10 +98,11 @@
 			
 			var thislink	= links[i],
 				href		= links[i].href,
-				ext			= /^([a-zA-Z]+?:(\/\/)?(www\.)?)/;
+				extreg		= (/^([a-zA-Z]+?:(\/\/)?(www\.)?)/).test( href ),
+				ext			= (baseElem && !extreg) || extreg;
 
 			//make sure it's an external stylesheet
-			if( thislink.rel.indexOf( "stylesheet" ) >= 0 && ext.test( href ) ){
+			if( thislink.rel.indexOf( "stylesheet" ) >= 0 && ext ){
 				(function( link ){			
 					fakejax( href, function( css ){
 						link.styleSheet.rawCssText = css;

--- a/respond.src.js
+++ b/respond.src.js
@@ -52,6 +52,7 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 		parsedSheets 	= {},
 		resizeThrottle	= 30,
 		head 			= doc.getElementsByTagName( "head" )[0] || docElem,
+		base			= doc.getElementsByTagName( "base" )[0],
 		links			= head.getElementsByTagName( "link" ),
 		requestQueue	= [],
 		
@@ -76,7 +77,7 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 						translate( sheet.styleSheet.rawCssText, href, media );
 						parsedSheets[ href ] = true;
 					} else {
-						if( !/^([a-zA-Z:]*\/\/)/.test( href )
+						if( (!base && !/^([a-zA-Z:]*\/\/)/.test( href ))
 							|| href.replace( RegExp.$1, "" ).split( "/" )[0] === win.location.host ){
 							requestQueue.push( {
 								href: href,


### PR DESCRIPTION
... tag is used
- Suppresses a false-positive when a <base> element exists but no link protocol is found.
- The x-domain script now correctly tests for the existence of a <base> element and proxies/redirects using that reference.
