### PR TITLE
Fix 'Operation aborted' error message in some versions of IE6.

### DIFF
--- a/respond.src.js
+++ b/respond.src.js
@@ -308,7 +308,7 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 		})();
 	
 	//translate CSS
-	if( document.attachEvent ){
+	if( document.attachEvent && document.readyState !== "complete" ){
 		// Avoid "Operation aborted" error in IE6 by waiting until the DOM is loaded.
 		var DOMLoaded = function() {
 			if( document.readyState === "complete" ) {


### PR DESCRIPTION
When using Respond.js at the end of the body element, some versions of IE will abort loading of the site with the message "Operation aborted". The site will not be rendered at all after this error occurs. This appears especially common with IE versions installed with tools such as MultipleIE.

This error is caused when the DOM is changed before the document is completely parsed. Attached is a fix, which just waits for the DOM ready event to fire if necessary.
