### PR TITLE
grab em value from a blank, unstyled document, rather than the current document.

### DIFF
--- a/respond.src.js
+++ b/respond.src.js
@@ -1,30 +1,30 @@
 /*! matchMedia() polyfill - Test a CSS media type/query in JS. Authors & copyright (c) 2012: Scott Jehl, Paul Irish, Nicholas Zakas. Dual MIT/BSD license */
 /*! NOTE: If you're already including a window.matchMedia polyfill via Modernizr or otherwise, you don't need this part */
 window.matchMedia = window.matchMedia || (function(doc, undefined){
-  
+
   var bool,
       docElem  = doc.documentElement,
       refNode  = docElem.firstElementChild || docElem.firstChild,
       // fakeBody required for <FF4 when executed in <head>
       fakeBody = doc.createElement('body'),
       div      = doc.createElement('div');
-  
+
   div.id = 'mq-test-1';
   div.style.cssText = "position:absolute;top:-100em";
   fakeBody.style.background = "none";
   fakeBody.appendChild(div);
-  
+
   return function(q){
-    
+
     div.innerHTML = '&shy;<style media="'+q+'"> #mq-test-1 { width: 42px; }</style>';
-    
+
     docElem.insertBefore(fakeBody, refNode);
-    bool = div.offsetWidth == 42;  
+    bool = div.offsetWidth == 42;
     docElem.removeChild(fakeBody);
-    
+
     return { matches: bool, media: q };
   };
-  
+
 })(document);
 
 
@@ -34,16 +34,16 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 (function( win ){
 	//exposed namespace
 	win.respond		= {};
-	
+
 	//define update even in native-mq-supporting browsers, to avoid errors
 	respond.update	= function(){};
-	
+
 	//expose media query support flag for external use
 	respond.mediaQueriesSupported	= win.matchMedia && win.matchMedia( "only all" ).matches;
-	
+
 	//if media queries are supported, exit here
 	if( respond.mediaQueriesSupported ){ return; }
-	
+
 	//define vars
 	var doc 			= win.document,
 		docElem 		= doc.documentElement,
@@ -56,7 +56,7 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 		base			= doc.getElementsByTagName( "base" )[0],
 		links			= head.getElementsByTagName( "link" ),
 		requestQueue	= [],
-		
+
 		//loop stylesheets, send text content to translate
 		ripCSS			= function(){
 			var sheets 	= links,
@@ -90,12 +90,12 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 			}
 			makeRequests();
 		},
-		
+
 		//recurse through request queue, get css text
 		makeRequests	= function(){
 			if( requestQueue.length ){
 				var thisRequest = requestQueue.shift();
-				
+
 				ajax( thisRequest.href, function( styles ){
 					translate( styles, thisRequest.href, thisRequest.media );
 					parsedSheets[ thisRequest.href ] = true;
@@ -103,7 +103,7 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 				} );
 			}
 		},
-		
+
 		//find media blocks in css text, convert to style blocks
 		translate			= function( styles, href, media ){
 			var qs			= styles.match(  /@media[^\{]+\{([^\{\}]*\{[^\}\{]*\})+/gi ),
@@ -119,20 +119,20 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 				j, fullq, thisq, eachq, eql;
 
 			//if path exists, tack on trailing slash
-			if( href.length ){ href += "/"; }	
-				
-			//if no internal queries exist, but media attr does, use that	
+			if( href.length ){ href += "/"; }
+
+			//if no internal queries exist, but media attr does, use that
 			//note: this currently lacks support for situations where a media attr is specified on a link AND
 				//its associated stylesheet has internal CSS media queries.
 				//In those cases, the media attribute will currently be ignored.
 			if( useMedia ){
 				ql = 1;
 			}
-			
+
 
 			for( ; i < ql; i++ ){
 				j	= 0;
-				
+
 				//media attr
 				if( useMedia ){
 					fullq = media;
@@ -143,65 +143,84 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 					fullq	= qs[ i ].match( /@media *([^\{]+)\{([\S\s]+?)$/ ) && RegExp.$1;
 					rules.push( RegExp.$2 && repUrls( RegExp.$2 ) );
 				}
-				
+
 				eachq	= fullq.split( "," );
 				eql		= eachq.length;
-					
+
 				for( ; j < eql; j++ ){
 					thisq	= eachq[ j ];
-					mediastyles.push( { 
+					mediastyles.push( {
 						media	: thisq.split( "(" )[ 0 ].match( /(only\s+)?([a-zA-Z]+)\s?/ ) && RegExp.$2 || "all",
 						rules	: rules.length - 1,
 						hasquery: thisq.indexOf("(") > -1,
-						minw	: thisq.match( /\(min\-width:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/ ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" ), 
+						minw	: thisq.match( /\(min\-width:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/ ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" ),
 						maxw	: thisq.match( /\(max\-width:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/ ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" )
 					} );
-				}	
+				}
 			}
 
 			applyMedia();
 		},
-        	
+
 		lastCall,
-		
+
 		resizeDefer,
-		
+
 		// returns the value of 1em in pixels
 		getEmValue		= function() {
 			var ret,
-				div = doc.createElement('div'),
 				body = doc.body,
+				iframe = doc.createElement('iframe'),
+				iframeDoc,
+				iframeDocElem,
+				iframeBody,
+				iframeTestElem,
 				fakeUsed = false;
-									
-			div.style.cssText = "position:absolute;font-size:1em;width:1em";
-					
+
+			iframe.style.cssText = "position:absolute;width:1px;height:1px;top:0;visibility:hidden;";
+
 			if( !body ){
 				body = fakeUsed = doc.createElement( "body" );
 				body.style.background = "none";
 			}
-					
-			body.appendChild( div );
-								
+
+			/* browsers will not create an empty document element unless the src
+			 * is set to something, like about:blank or javascript:false */
+			iframe.src = 'about:blank';
+
+			body.appendChild( iframe );
+
 			docElem.insertBefore( body, docElem.firstChild );
-								
-			ret = div.offsetWidth;
-								
+
+			// get iframe's document element
+			iframeDoc = iframe.contentDocument ?
+							iframe.contentDocument : (
+								iframe.contentWindow.document ||
+								iframe.document
+							);
+			iframeDoc.open();
+			iframeDoc.write("<html><body><div id=\'testElem\' style=\'width:1em;\'></div></body></html>");
+			iframeDoc.close();
+
+			iframeTestElem = iframeDoc.getElementById('testElem');
+			ret = iframeTestElem.offsetWidth;
+
 			if( fakeUsed ){
 				docElem.removeChild( body );
 			}
 			else {
-				body.removeChild( div );
+				body.removeChild( iframe );
 			}
-			
+
 			//also update eminpx before returning
 			ret = eminpx = parseFloat(ret);
-								
+
 			return ret;
 		},
-		
-		//cached container for 1em value, populated the first time it's needed 
+
+		//cached container for 1em value, populated the first time it's needed
 		eminpx,
-		
+
 		//enable/disable styles
 		applyMedia			= function( fromResize ){
 			var name		= "clientWidth",
@@ -211,7 +230,7 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 				lastLink	= links[ links.length-1 ],
 				now 		= (new Date()).getTime();
 
-			//throttle resize calls	
+			//throttle resize calls
 			if( fromResize && lastCall && now - lastCall < resizeThrottle ){
 				clearTimeout( resizeDefer );
 				resizeDefer = setTimeout( applyMedia, resizeThrottle );
@@ -220,7 +239,7 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 			else {
 				lastCall	= now;
 			}
-										
+
 			for( var i in mediastyles ){
 				var thisstyle = mediastyles[ i ],
 					min = thisstyle.minw,
@@ -228,14 +247,14 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 					minnull = min === null,
 					maxnull = max === null,
 					em = "em";
-				
+
 				if( !!min ){
 					min = parseFloat( min ) * ( min.indexOf( em ) > -1 ? ( eminpx || getEmValue() ) : 1 );
 				}
 				if( !!max ){
 					max = parseFloat( max ) * ( max.indexOf( em ) > -1 ? ( eminpx || getEmValue() ) : 1 );
 				}
-				
+
 				// if there's no media query at all (the () part), or min or max is not null, and if either is present, they're true
 				if( !thisstyle.hasquery || ( !minnull || !maxnull ) && ( minnull || currWidth >= min ) && ( maxnull || currWidth <= max ) ){
 						if( !styleBlocks[ thisstyle.media ] ){
@@ -244,33 +263,33 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 						styleBlocks[ thisstyle.media ].push( rules[ thisstyle.rules ] );
 				}
 			}
-			
+
 			//remove any existing respond style element(s)
 			for( var i in appendedEls ){
 				if( appendedEls[ i ] && appendedEls[ i ].parentNode === head ){
 					head.removeChild( appendedEls[ i ] );
 				}
 			}
-			
+
 			//inject active styles, grouped by media type
 			for( var i in styleBlocks ){
 				var ss		= doc.createElement( "style" ),
 					css		= styleBlocks[ i ].join( "\n" );
-				
-				ss.type = "text/css";	
+
+				ss.type = "text/css";
 				ss.media	= i;
-				
+
 				//originally, ss was appended to a documentFragment and sheets were appended in bulk.
 				//this caused crashes in IE in a number of circumstances, such as when the HTML element had a bg image set, so appending beforehand seems best. Thanks to @dvelyk for the initial research on this one!
 				head.insertBefore( ss, lastLink.nextSibling );
-				
-				if ( ss.styleSheet ){ 
+
+				if ( ss.styleSheet ){
 		        	ss.styleSheet.cssText = css;
-		        } 
+		        }
 		        else {
 					ss.appendChild( doc.createTextNode( css ) );
 		        }
-		        
+
 				//push to appendedEls to track for later removal
 				appendedEls.push( ss );
 			}
@@ -280,7 +299,7 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 			var req = xmlHttp();
 			if (!req){
 				return;
-			}	
+			}
 			req.open( "GET", url, true );
 			req.onreadystatechange = function () {
 				if ( req.readyState != 4 || req.status != 200 && req.status != 304 ){
@@ -293,9 +312,9 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 			}
 			req.send( null );
 		},
-		//define ajax obj 
+		//define ajax obj
 		xmlHttp = (function() {
-			var xmlhttpmethod = false;	
+			var xmlhttpmethod = false;
 			try {
 				xmlhttpmethod = new XMLHttpRequest();
 			}
@@ -306,13 +325,13 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 				return xmlhttpmethod;
 			};
 		})();
-	
+
 	//translate CSS
 	ripCSS();
-	
+
 	//expose update for re-running respond later on
 	respond.update = ripCSS;
-	
+
 	//adjust on resize
 	function callMedia(){
 		applyMedia( true );


### PR DESCRIPTION
I've been doing a lot of testing (cf. [Issue 128](https://github.com/scottjehl/Respond/issues/128)) and discovered that, when you write a media query with relative (em) values, supporting browsers use the user agent's stylesheet as the reference for the size of an em. Respond, because it injects a test `div` into the document, uses the document's base font size. In cases where someone has a stylesheet like this:

``` css
:root, body { font-size: 62.5% /* make 1em = 10px */ }
```

Respond applies breakpoints at incorrect em sizes; 10px rather than 16px (or whatever the user has set up their default font size as).

This pull request modifies the `getEmValue()` function to inject an invisible blank `iframe` into the document, creates a basic document with a test `<div style="width:1em;">`, and gets the `offsetWidth` of that `div`. Basically the same technique as before, except all the measuring happens in that `iframe`. Since that `iframe` is unstyled, `getEmValue()` will always get the em value from the user agent stylesheet.

Tested successfully on IE6, IE8, Firefox 3.0 and 3.5. It didn't seem to work on Safari 3 or 4.

Demos (with base font size set to 75%):

http://heliosstudio.ca/respond-test/respond-test.php?rootsize=75 (current behaviour, with Respond pulled from current master)
http://heliosstudio.ca/respond-test/respond-test-iframe.php?rootsize=75 (my pull request)

Resize the window; in browsers that support media queries, you'll see that there's a mismatch between breakpoints in the first demo. In the second demo, they match. (In Internet Explorer, the browser's media query engine and Respond both report the same breakpoints, but that's because Respond _is_ the media query engine :-) In the first demo, the breakpoint is at too narrow a point, and in the second demo, it matches the behaviour of other browsers.)
