### PR TITLE
Fixed bug in For Loop

### DIFF
--- a/respond.src.js
+++ b/respond.src.js
@@ -222,6 +222,9 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
 			}
 										
 			for( var i in mediastyles ){
+				if (!mediastyles.hasOwnProperty(i)) {
+					continue;
+				}
 				var thisstyle = mediastyles[ i ],
 					min = thisstyle.minw,
 					max = thisstyle.maxw,


### PR DESCRIPTION
I was experiencing this problem in IE8.  

http://stackoverflow.com/questions/1107681/javascript-hiding-prototype-methods-in-for-loop

It was only IE8 (didn't try earlier versions of IE) and only on one page.  Despite spending a considerable amount of time I could not understand what about this page triggers the problem.  In any case the code is better with this change.  For-in loops are somewhat inherently dangerous because of this problem.
