### PR TITLE
More flexible MQ syntax

### DIFF
--- a/respond.src.js
+++ b/respond.src.js
@@ -163,8 +163,8 @@ window.matchMedia = window.matchMedia || (function( doc, undefined ) {
 						media : thisq.split( "(" )[ 0 ].match( /(only\s+)?([a-zA-Z]+)\s?/ ) && RegExp.$2 || "all",
 						rules : rules.length - 1,
 						hasquery : thisq.indexOf("(") > -1,
-						minw : thisq.match( /\(min\-width:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/ ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" ), 
-						maxw : thisq.match( /\(max\-width:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/ ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" )
+						minw : thisq.match( /\(\s*min\-width:\s*(\s*[0-9\.]+)(px|em)\s*\)/ ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" ), 
+						maxw : thisq.match( /\(\s*max\-width:\s*(\s*[0-9\.]+)(px|em)\s*\)/ ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" )
 					} );
 				}	
 			}


### PR DESCRIPTION
Little bit more flexible syntax in MQ allows white-space between opening ( and min/max-width. White-space was already allowed prior to ending ).
