### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,10 @@
+{
+  "name": "respond",
+  "version": "1.2.0",
+  "main": "respond.src.js",
+  "description": "Fast and lightweight polyfill for min/max-width CSS3 Media Queries (for IE 6-8, and more)"
+  "ignore": [
+    "**/.*",
+    "test"
+  ]
+}


### PR DESCRIPTION
This file allows this package to be installed using Bower. The package
has already been registered as `respond` in the Bower package registry.
It can now be installed by executing:

  bower install respond

More information on Bower can be found at:

  https://github.com/bower/bower
  http://bower.io
