### PR TITLE
win.matchMedia("only all") can be null

### DIFF
--- a/respond.src.js
+++ b/respond.src.js
@@ -51,7 +51,7 @@ window.matchMedia = window.matchMedia || (function( doc, undefined ) {
 	respond.update = function(){};
 	
 	//expose media query support flag for external use
-	respond.mediaQueriesSupported	= win.matchMedia && win.matchMedia( "only all" ).matches;
+	respond.mediaQueriesSupported	= win.matchMedia && win.matchMedia( "only all" ) != null && win.matchMedia( "only all" ).matches;
 	
 	//if media queries are supported, exit here
 	if( respond.mediaQueriesSupported ){


### PR DESCRIPTION
In Firefox win.matchMedia("only all") can be null - this stops an error being thrown.
