### PR TITLE
Fix memory leak with appendedEls

### DIFF
--- a/src/respond.js
+++ b/src/respond.js
@@ -187,6 +187,7 @@
 					}
 				}
 			}
+			appendedEls.length = 0;
 
 			//inject active styles, grouped by media type
 			for( var k in styleBlocks ){


### PR DESCRIPTION
The list of appended style elements `appendedEls` is never cleared, preventing the style elements from being garbage collected.

This change clears the list after the style elements have been removed from the DOM.
