### PR TITLE
adding an alternative for cross-domain issues

### DIFF
--- a/src/respond.js
+++ b/src/respond.js
@@ -303,7 +303,8 @@
 
 			for( var i = 0; i < links.length; i++ ){
 				var sheet = links[ i ],
-				parsedHref = href = sheet.href,
+				href = sheet.href,
+				parsedHref = href,
 				respondHref = sheet.getAttribute('data-respond-href'),
 				media = sheet.media,
 				isCSS = sheet.rel && sheet.rel.toLowerCase() === "stylesheet";
@@ -315,14 +316,14 @@
 						translate( sheet.styleSheet.rawCssText, href, media );
 						parsedSheets[ parsedHref ] = true;
 					} else {
-				        if (respondHref) {
-				            requestQueue.push({
-				            	href: respondHref,
-				            	media: media,
-				            	parsedHref: parsedHref
-				            });
-				        } else if( (!/^([a-zA-Z:]*\/\/)/.test( href ) && !base) ||
-							       href.replace( RegExp.$1, "" ).split( "/" )[0] === w.location.host ){
+						if (respondHref) {
+							requestQueue.push({
+								href: respondHref,
+								media: media,
+								parsedHref: parsedHref
+							});
+						} else if( (!/^([a-zA-Z:]*\/\/)/.test( href ) && !base) ||
+								   href.replace( RegExp.$1, "" ).split( "/" )[0] === w.location.host ){
 							// IE7 doesn't handle urls that start with '//' for ajax request
 							// manually add in the protocol
 							if ( href.substring(0,2) === "//" ) { href = w.location.protocol + href; }


### PR DESCRIPTION
I found the cross-domain fix using a proxy tedious to integrate into my project (due to how we setup all our code for our CDN etc) so I came up with a different solution;  
Just fetch the same stylesheet again, without using the CDN.  

I'm okay with a small percentage of my users not using the CDN and it makes my life A LOT easier :-).

Instead of adding a lot of 'magic' I just added a new attribute on my `<link>` called `respond-href` with the URL to load instead, keeping it explicit, though adding an 'invalid' attribute, but I think Respond is mostly for people who're building a HTML5 website anyway, so you won't be passing the old validators anyway?

``` html
<link rel="stylesheet" type="text/css" 
      href="cdn.domain.com/statics/stylesheet.css"
      respond-href="/statics/stylesheet.css" />
```
