### PR TITLE
Adding callMedia() when calling respond.update()

### DIFF
--- a/src/respond.js
+++ b/src/respond.js
@@ -328,6 +328,7 @@
 				}
 			}
 			makeRequests();
+			callMedia();
 		};
 
 	//translate CSS


### PR DESCRIPTION
When adding an already parsed CSS file to a page, the media-queries don't get re-applyed when calling respond.update().
For example, if you have a CSS Theme chooser that : 
- remove old CSS file from HEAD
- adds new one to HEAD
- call respond.update()

The next bug occurs :
- loading page with theme A => OK
- changing theme for theme B => OK
- changing theme for theme A => KO
- changing theme for theme B => KO
- changing theme for theme A => KO
- changing theme for theme B => KO
- ....
