### PR TITLE
Add support for <base> tag

### DIFF
--- a/src/respond.js
+++ b/src/respond.js
@@ -323,6 +323,16 @@
 								href: href,
 								media: media
 							} );
+						}else if(!/^([a-zA-Z:]*\/\/)/.test(href) && base){
+							if (href.substring(0, 1) === "/") {//absolute path
+								href = w.location.protocol + "//" + w.location.host + href;
+							}else{//relative
+								href = base.href + href;
+							}
+							requestQueue.push({
+								href: href,
+								media: media
+							});
 						}
 					}
 				}


### PR DESCRIPTION
If impossible to remove base tag from the document, one can add the following lines to add support for base tag.
