### PR TITLE
Fix proxy when it path contains query string

### DIFF
--- a/cross-domain/respond.proxy.js
+++ b/cross-domain/respond.proxy.js
@@ -30,7 +30,7 @@
 			docElem.insertBefore(iframe, docElem.firstElementChild || docElem.firstChild );
 		}
 
-		iframe.src = checkBaseURL(proxyURL) + "?url=" + encode(redirectURL) + "&css=" + encode(checkBaseURL(url));
+		iframe.src = checkBaseURL(proxyURL) + (proxyURL.indexOf('?') === -1 ? '?' : '&')  + "url=" + encode(redirectURL) + "&css=" + encode(checkBaseURL(url));
 		
 		function checkFrameName() {
 			var cssText;


### PR DESCRIPTION
We using Respond together with Symfony2 and generated url looks like ``//assets.site.com/js/respond/respond-proxy.html?_assets_version=123`. So library doesn't work properly without this patch.
