### PR TITLE
Change CSS test to match inline credentials

### DIFF
--- a/src/respond.js
+++ b/src/respond.js
@@ -315,7 +315,8 @@
 						parsedSheets[ href ] = true;
 					} else {
 						if( (!/^([a-zA-Z:]*\/\/)/.test( href ) && !base) ||
-							href.replace( RegExp.$1, "" ).split( "/" )[0] === w.location.host ){
+							href.replace( RegExp.$1, "" ).split( "/" )[0] === w.location.host ||
+							href.replace( RegExp.$1, "" ).split( "/" )[0].replace(/^[a-zA-Z0-9]+:[a-zA-Z0-9]+@/, "") === w.location.host ){
 							// IE7 doesn't handle urls that start with '//' for ajax request
 							// manually add in the protocol
 							if ( href.substring(0,2) === "//" ) { href = w.location.protocol + href; }


### PR DESCRIPTION
Fixes issue #326, Fails to rip CSS when inline credentials are used in the URL.

CSS URLs of the format http://username:password@host.com/ do not pass the validation necessary to add them to the queue of files to request via AJAX.
