### PR TITLE
Add main field so it can be `require`d in webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"type": "git",
 		"url": "https://github.com/scottjehl/Respond.git"
 	},
+	"main": "dest/respond.src.js",
 	"bugs": {
 		"url": "https://github.com/scottjehl/Respond/issues"
 	},


### PR DESCRIPTION
After `npm install`ing respond.js, Webpack throws a "cannot resolve module" error since there's no `main` field in package.json. This pull fixes that.