### PR TITLE
Set default jsDelivr file (closes #368)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "Respond.js",
 	"description": "min/max-width media query polyfill",
+	"jsdelivr": "dest/respond.min.js",
 	"version": "1.4.2",
 	"homepage": "https://github.com/scottjehl/Respond",
 	"homepageShortened": "https://j.mp/respondjs",


### PR DESCRIPTION
This makes it easier for people to find the correct file at jsDelivr CDN website: https://www.jsdelivr.com/package/npm/respond.js